### PR TITLE
Add job failure detection to parallelize

### DIFF
--- a/scripts/parallelize
+++ b/scripts/parallelize
@@ -321,10 +321,15 @@ do_parallelize ()
       # before the 1st process is finished.
       if [ "$SIZE_OF_ARRAY" -gt 1 ]; then
         echo "$i/$SIZE_OF_ARRAY" > "$PROGRESS_DIR/job0.progress"
+        echo 0 > "$PROGRESS_DIR/job0.status"
       fi
 
       for file in "${ARRAY[@]}"; do
           eval "$COMMAND \"$file\""  # Use eval to handle complex commands
+          exit_code=$?
+          if [ $exit_code -ne 0 ]; then
+            echo 1 > "$PROGRESS_DIR/job0.status"
+          fi
           ((i++))
           
           if [ "$SIZE_OF_ARRAY" -gt 1 ]; then
@@ -392,6 +397,7 @@ do_parallelize ()
           total_k=\$(echo ${ARG_LIST[$i]} | wc -w)
           k_count=0
           echo \"\$k_count/\$total_k\" > \"$PROGRESS_DIR/job${i}.progress\"
+          echo 0 > \"$PROGRESS_DIR/job${i}.status\"
           for k in ${ARG_LIST[$i]}; do
             ((k_count++))
               
@@ -399,6 +405,10 @@ do_parallelize ()
             echo \"Processing \$k (\$k_count/\$total_k)\" >> \"$log\"
   
             $COMMAND \$k >> \"$log\" 2>&1
+            exit_code=$?
+            if [ \$exit_code -ne 0 ]; then
+              echo 1 > \"$PROGRESS_DIR/job${i}.status\"
+            fi
 
             # Update progress file (instead of printing progress)
             echo \"\$k_count/\$total_k\" > \"$PROGRESS_DIR/job${i}.progress\"

--- a/scripts/progress_bar_multi.sh
+++ b/scripts/progress_bar_multi.sh
@@ -42,7 +42,8 @@ main ()
   if [ -z "$color" ]; then color=2; fi
   if [ -z "$width" ]; then width=40; fi
 
-  COLOR=$(tput setaf $color)
+  DEFAULT_COLOR=$(tput setaf $color)
+  FAIL_COLOR=$(tput setaf 1)
   
   # Print empty lines for each job
   for ((i=0; i<n_jobs; i++)); do
@@ -65,7 +66,17 @@ main ()
         bar+=$(printf "%${unfilled}s")
         jobnumber=$((i+1))
         printf -v jobstr "%2d" "$jobnumber"
-        echo -ne "Job ${jobstr}: [${COLOR}${bar}${NC}] (${percent}%)\n"
+
+        status_file="$PROGRESS_DIR/job${i}.status"
+        status=0
+        [[ -f "$status_file" ]] && status=$(cat "$status_file")
+        if [[ "$status" -ne 0 ]]; then
+          BAR_COLOR=$FAIL_COLOR
+        else
+          BAR_COLOR=$DEFAULT_COLOR
+        fi
+
+        echo -ne "Job ${jobstr}: [${BAR_COLOR}${bar}${NC}] (${percent}%)\n"
         [[ "$done_items" -lt "$total_items" ]] && all_done=false
       else
         echo -ne "Job $((i+1)): [waiting...]\n"
@@ -93,6 +104,7 @@ ${BOLD}OPTIONS:${NC}
   width   Width of progress bar (default $width).
   color   Color code (default $color).
           (0-black, 1-red, 2-green, 3-yellow, 4-blue, 5-pink, 6-cyan, 7-white)
+  Failed jobs are displayed in red regardless of the chosen color.
 
 ${BOLD}EXAMPLE:${NC}
   #! /bin/bash


### PR DESCRIPTION
## Summary
- detect failed commands in `parallelize`
- report job status in `progress_bar_multi.sh`
- display failed jobs in red in progress output

## Testing
- `ruff check src scripts` *(fails: many existing issues)*
- `black --check src scripts`
- `python -m compileall src`
- `pip install -r requirements.txt` *(fails: proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_687e271d1520832c84212d874a9a258f