### PR TITLE
chore: require Python 3.9

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -18,7 +18,7 @@ T1Prep/
 ```
 
 ## Development Guidelines
-- Use Python 3.8 or newer.
+- Use Python 3.9 or newer.
 - Keep functions small and well documented. Include docstrings for public functions.
 - Prefer using the utilities provided in `src/utils.py` when possible.
 - Check documentation of functions and add missing documentation.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ As with other DL-based methods, DeepMriPrep slightly underestimates gray matter 
 Cortical surface reconstruction and thickness estimation are performed using [Cortex Analysis Tools for Surface](https://github.com/ChristianGaser/CAT-Surface), a core component of the [CAT12 toolbox](https://github.com/ChristianGaser/cat12).
 
 ## Requirements
-Python 3.8 (or higher) is required, and all necessary libraries are automatically installed the first time T1Prep is run.
+ Python 3.9 (or higher) is required, and all necessary libraries are automatically installed the first time T1Prep is run.
 
 ## Main Differences to CAT12
 - Implemented entirely in Python and C, eliminating the need for a Matlab license.
@@ -84,10 +84,10 @@ Python 3.8 (or higher) is required, and all necessary libraries are automaticall
     Only segmentation maps are generated and saved in the same directory as the input files.
 
 ```bash
-  ./scripts/T1Prep --python python3.8 --no-overwrite "surf/lh.thickness." sTRIO*.nii
+  ./scripts/T1Prep --python python3.9 --no-overwrite "surf/lh.thickness." sTRIO*.nii
 ```
-    Process all files matching the pattern 'sTRIO*.nii' and use python3.8. Skip processing 
-    for files where 'surf/lh.thickness.*' already exists, and save new results in the same 
+    Process all files matching the pattern 'sTRIO*.nii' and use python3.9. Skip processing
+    for files where 'surf/lh.thickness.*' already exists, and save new results in the same
     directory as the input files.
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Christian Gaser", email = "christian.gaser@uni-jena.de" },
 ]
 license = {text = "Apache License Version 2.0"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 readme = "README.md"
 repository = "https://github.com/ChristianGaser/T1Prep"
 
@@ -18,7 +18,6 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/scripts/T1Prep
+++ b/scripts/T1Prep
@@ -330,7 +330,14 @@ check_python()
   if ! command -v "${python}" &>/dev/null; then
     echo "${RED}ERROR: $python not found${NC}" >&2
     exit 1
-  fi  
+  fi
+
+  required="3.9"
+  py_version="$(${python} -V 2>&1 | awk '{print $2}')"
+  if [ "$(printf '%s\n' "${required}" "${py_version}" | sort -V | head -n1)" != "${required}" ]; then
+    echo "${RED}ERROR: Python ${required} or newer is required (found ${py_version}).${NC}" >&2
+    exit 1
+  fi
 }
 
 # ----------------------------------------------------------------------
@@ -1033,9 +1040,9 @@ ${BLUE}${root_dir}/T1Prep --no-surf sTRIO*.nii${NC}
   Process all files matching the pattern 'sTRIO*.nii', but skip surface creation. 
   Only segmentation maps are generated and saved in the same directory as the input files.
 
-${BLUE}${root_dir}/T1Prep --python python3.8 --no-overwrite "surf/lh.thickness." sTRIO*.nii${NC}
-  Process all files matching the pattern 'sTRIO*.nii' and use python3.8. Skip processing 
-  for files where 'surf/lh.thickness.*' already exists, and save new results in the same 
+${BLUE}${root_dir}/T1Prep --python python3.9 --no-overwrite "surf/lh.thickness." sTRIO*.nii${NC}
+  Process all files matching the pattern 'sTRIO*.nii' and use python3.9. Skip processing
+  for files where 'surf/lh.thickness.*' already exists, and save new results in the same
   directory as the input files.
 
 ${BLUE}${root_dir}/T1Prep --lesions --no-sphere-reg sTRIO*.nii${NC}


### PR DESCRIPTION
## Summary
- ensure `scripts/T1Prep` runs with Python 3.9 or newer
- document Python 3.9 requirement and adjust packaging

## Testing
- `pip install -r requirements.txt`
- `black --check src scripts` *(fails: would reformat 3 files)*
- `flake8 src scripts` *(command not found)*
- `shellcheck scripts/T1Prep` *(command not found)*
- `python -m compileall src`
- `pytest` *(fails: ModuleNotFoundError: No module named 'memory_profiler')*


------
https://chatgpt.com/codex/tasks/task_e_689b0bfc6968832cbb8967c6f1832740