### PR TITLE
chore: add Dockerfile update workflow

### DIFF
--- a/.github/workflows/update-dockerfile.yml
+++ b/.github/workflows/update-dockerfile.yml
@@ -1,0 +1,19 @@
+name: Update Dockerfile
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  bump-dockerfile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update Dockerfile
+        run: |
+          tag=${{ github.event.release.tag_name }}
+          sed -i -E "s/ARG T1PREP_VERSION=.*/ARG T1PREP_VERSION=${tag}/" Dockerfile
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git commit -am "chore: bump Dockerfile to ${tag}"
+          git push


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to bump Dockerfile ARG on release publish

## Testing
- `pip install -r requirements.txt`
- `black --check src scripts` (fails: would reformat files)
- `flake8 src scripts` (fails: command not found / install blocked)
- `python -m compileall src`


------
https://chatgpt.com/codex/tasks/task_e_68ad67110554832c9a9673afcf1ceab6