### PR TITLE
Potential fix for code scanning alert no. 9: Uncontrolled data used in path expression

### DIFF
--- a/webui/app.py
+++ b/webui/app.py
@@ -799,9 +799,16 @@ def resolve_dirname():
     if not raw_path:
         return jsonify({"dirname": ""})
 
+    safe_root = DEFAULT_UPLOAD_ROOT.resolve()
     p = Path(raw_path).expanduser()
     if not p.is_absolute():
-        p = ROOT_DIR / p
+        p = safe_root / p
+    p = p.resolve(strict=False)
+
+    try:
+        p.relative_to(safe_root)
+    except ValueError:
+        return jsonify({"dirname": ""})
 
     # If path exists and is a directory, use it directly
     if p.exists() and p.is_dir():


### PR DESCRIPTION
Potential fix for [https://github.com/ChristianGaser/T1Prep/security/code-scanning/9](https://github.com/ChristianGaser/T1Prep/security/code-scanning/9)

The best fix is to **canonicalize and constrain** all user-provided paths to a safe base directory before any filesystem checks or response output.

In `webui/app.py`, inside `resolve_dirname`:
- Keep reading `raw_path` as now.
- Build a candidate path from user input.
- Expand `~`, make relative paths rooted under a safe root (`DEFAULT_UPLOAD_ROOT` is a good project-defined location), and resolve (`Path.resolve(strict=False)`) to normalize `..` and symlinks where possible.
- Verify the resolved path is inside the safe root using `relative_to` (or equivalent). If outside, return empty dirname.
- Use this validated path for the existing directory/file heuristics and responses.

No new dependency is needed; use `pathlib` already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
