### PR TITLE
Potential fix for code scanning alert no. 11: Uncontrolled data used in path expression

### DIFF
--- a/webui/app.py
+++ b/webui/app.py
@@ -809,10 +809,16 @@ def resolve_dirname():
         return jsonify({"dirname": ""})
 
     safe_root = DEFAULT_UPLOAD_ROOT.resolve()
-    p = Path(raw_path).expanduser()
-    if not p.is_absolute():
-        p = safe_root / p
-    p = p.resolve(strict=False)
+
+    # Sanitize untrusted input before using it in path construction.
+    if "\x00" in raw_path:
+        return jsonify({"dirname": ""})
+    normalized_raw = raw_path.replace("\\", "/").lstrip("/")
+    parts = [part for part in normalized_raw.split("/") if part not in ("", ".")]
+    if any(part == ".." for part in parts):
+        return jsonify({"dirname": ""})
+
+    p = (safe_root / Path(*parts)).resolve(strict=False)
 
     try:
         p.relative_to(safe_root)


### PR DESCRIPTION
Potential fix for [https://github.com/ChristianGaser/T1Prep/security/code-scanning/11](https://github.com/ChristianGaser/T1Prep/security/code-scanning/11)

General fix: sanitize and normalize the user input **before** creating a `Path`, reject clearly unsafe path forms (null bytes, absolute external forms), and only then join with a trusted root and enforce containment.

Best fix in this snippet (within `resolve_dirname`):  
- In `webui/app.py`, in `resolve_dirname`, add a strict validation step on `raw_path`:
  - reject null byte input;
  - normalize separators to `/`;
  - strip leading `/` so input is always treated as root-relative under `safe_root`;
  - reject traversal segments (`..`) prior to path construction.
- Then construct `p` from the sanitized relative path under `safe_root`, resolve, and keep the existing `relative_to(safe_root)` guard.

This preserves existing behavior (resolving a directory/file guess and returning dirname) while removing direct unsafe interpretation of raw user path input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
