### PR TITLE
Potential fix for code scanning alert no. 8: Uncontrolled data used in path expression

### DIFF
--- a/webui/app.py
+++ b/webui/app.py
@@ -464,6 +464,17 @@ def atlas_help():
     truncated = len(lines) > 20
 
     return jsonify({"name": name, "text": preview, "truncated": truncated})
+def _resolve_out_dir_within_root(root: Path, user_value: str) -> Path:
+    user_path = Path(user_value.strip())
+    if not user_value or user_path.is_absolute():
+        raise ValueError("Output directory must be within the application root.")
+
+    root_resolved = root.resolve(strict=True)
+    candidate = (root_resolved / user_path).resolve(strict=False)
+    candidate.relative_to(root_resolved)
+    return candidate
+
+
 @app.route("/submit", methods=["POST"])
 def submit():
     ensure_dirs()
@@ -485,14 +496,8 @@ def submit():
     if not out_dir_str:
         return "Output directory is required.", 400
 
-    user_out_dir = Path(out_dir_str.strip())
-    if not out_dir_str or user_out_dir.is_absolute() or ".." in user_out_dir.parts:
-        return "Output directory must be within the application root.", 400
-
-    safe_root = ROOT_DIR.resolve(strict=True)
-    out_dir = (safe_root / user_out_dir).resolve(strict=False)
     try:
-        out_dir.relative_to(safe_root)
+        out_dir = _resolve_out_dir_within_root(ROOT_DIR, out_dir_str)
     except ValueError:
         return "Output directory must be within the application root.", 400
     out_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Potential fix for [https://github.com/ChristianGaser/T1Prep/security/code-scanning/8](https://github.com/ChristianGaser/T1Prep/security/code-scanning/8)

General fix: for any user-controlled filesystem path, canonicalize and constrain it to a trusted base directory before any filesystem operation. Prefer a single validation function that (1) rejects absolute paths, (2) resolves against a fixed root, and (3) verifies the resolved candidate is inside that root.

Best fix here (without changing behavior): in `webui/app.py` inside `submit()`, replace the current inline checks with a dedicated safe-join helper using `Path.resolve()` and `relative_to()` (or `is_relative_to` when available). Keep the same error response when invalid. This keeps current functionality (user chooses a relative output folder under app root) while making validation explicit and robust for analysis and maintenance.

Edits needed in shown region:
- Add a small helper function above `submit()` (in `webui/app.py`) to resolve and validate output path containment.
- Replace lines 488–497 logic with a call to the helper wrapped in `try/except ValueError`.
- Keep line 498 (`mkdir`) but now operating on helper-validated `out_dir`.

No new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
